### PR TITLE
Adding mrpt navigation travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ env:
     - CI_SOURCE_PATH=$(pwd)
     - ROSINSTALL_FILE=$CI_SOURCE_PATH/dependencies.rosinstall
     - CATKIN_OPTIONS=$CI_SOURCE_PATH/catkin.options
-    - ROS_PARALLEL_JOBS='-j1 -l6'
+    - ROS_PARALLEL_JOBS='-j6 -l6'
 
 ################################################################################
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,6 +58,7 @@ install:
 before_script:
   # source dependencies: install using wstool.
   - cd ~/catkin_ws/src
+  - git clone https://github.com/mrpt-ros-pkg/mrpt_navigation.git
   - wstool init
   - if [[ -f $ROSINSTALL_FILE ]] ; then wstool merge $ROSINSTALL_FILE ; fi
   - wstool up


### PR DESCRIPTION
This PR adds mrpt_navigation dependency in travis and increases the number of catking_make parallel jobs. It should make build of the PR https://github.com/mrpt-ros-pkg/mrpt_slam/pull/5 successful in travis.