### PR TITLE
Add installation from ppa in Travis and 	skip mrpt_ekf_slam_3d if version of MRPT is lower than 1.5.0.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ env:
 before_install:
   - sudo sh -c "echo \"deb http://packages.ros.org/ros/ubuntu $ROS_CI_DESKTOP main\" > /etc/apt/sources.list.d/ros-latest.list"
   - wget http://packages.ros.org/ros.key -O - | sudo apt-key add -
+  - sudo add-apt-repository ppa:joseluisblancoc/mrpt -y
   - sudo apt-get update -qq
   - sudo apt-get install -y python-catkin-pkg python-rosdep python-wstool ros-$ROS_DISTRO-catkin
   - source /opt/ros/$ROS_DISTRO/setup.bash
@@ -37,7 +38,7 @@ before_install:
   - sudo apt-get install -y libdc1394-22-dev libavformat-dev libswscale-dev
   - sudo apt-get install -y libassimp-dev libjpeg-dev libopencv-dev libgtest-dev
   - sudo apt-get install -y libeigen3-dev libsuitesparse-dev libpcap-dev
-  - sudo apt-get -y install libmrpt-dev
+  - sudo apt-get install -y libmrpt-dev mrpt-apps
 
 # Create a catkin workspace with the package under integration.
 install:

--- a/mrpt_ekf_slam_3d/CMakeLists.txt
+++ b/mrpt_ekf_slam_3d/CMakeLists.txt
@@ -50,3 +50,8 @@ add_executable(mrpt_ekf_slam_3d
 TARGET_LINK_LIBRARIES(mrpt_ekf_slam_3d ${MRPT_LIBS}
     ${catkin_LIBRARIES}  ${Eigen_LIBRARIES}
 )
+
+IF(${MRPT_VERSION} LESS 1.5.0)
+  MESSAGE(WARNING "Target mrpt_ekf_slam_3d will not be built. It requires MRPT version 1.5.0 or higher, but you have ${MRPT_VERSION}.")
+  set_target_properties(mrpt_ekf_slam_3d PROPERTIES EXCLUDE_FROM_ALL 1 EXCLUDE_FROM_DEFAULT_BUILD 1)
+endif()


### PR DESCRIPTION
This pull request is a part of the GSOC project "ROS packages for versatile RBPF-based SLAM". More information https://github.com/MRPT/GSoC2016-discussions/issues/3