### PR TITLE
Remove installation of the demo directory from mrpt_graphslam_2d.

### DIFF
--- a/mrpt_graphslam_2d/CMakeLists.txt
+++ b/mrpt_graphslam_2d/CMakeLists.txt
@@ -155,7 +155,6 @@ else()
   # Mark other files for installation (e.g. launch and bag files, etc.)
   install(DIRECTORY
     launch
-    demo
     config
     rviz
     rosbags


### PR DESCRIPTION
It doesn't exist, so causes problems at the last stage of cmake.

This will fix at least one of the problems preventing this from successfully building binary packages on Melodic, i.e. http://build.ros.org/view/Mbin_uB64/job/Mbin_uB64__mrpt_graphslam_2d__ubuntu_bionic_amd64__binary/5/

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>