### PR TITLE
setting trajectory publishers to latched

### DIFF
--- a/mrpt_graphslam_2d/include/mrpt_graphslam_2d/CGraphSlamHandler_ROS_impl.h
+++ b/mrpt_graphslam_2d/include/mrpt_graphslam_2d/CGraphSlamHandler_ROS_impl.h
@@ -385,13 +385,16 @@ void CGraphSlamHandler_ROS<GRAPH_T>::setupPubs() {
   // agent estimated position
   m_curr_robot_pos_pub = m_nh->advertise<geometry_msgs::PoseStamped>(
 	  m_curr_robot_pos_topic,
-	  m_queue_size);
+	  m_queue_size,
+	  true);
   m_robot_trajectory_pub = m_nh->advertise<nav_msgs::Path>(
 	  m_robot_trajectory_topic,
-	  m_queue_size);
+	  m_queue_size,
+	  true);
   m_robot_tr_poses_pub = m_nh->advertise<geometry_msgs::PoseArray>(
 	  m_robot_tr_poses_topic,
-	  m_queue_size);
+	  m_queue_size,
+	  true);
 
   // odometry nav_msgs::Path
   m_odom_path.header.seq = 0;


### PR DESCRIPTION
So you can obtain data when running mrpt_graphslam with a bagfile, even after the playback has finished.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mrpt-ros-pkg/mrpt_slam/65)
<!-- Reviewable:end -->
